### PR TITLE
Set permissions on db.ini when mounting secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ This is a set of Docker images and a Docker swarm workflow for deploying [Omeka 
 * Docker CE 17.12 or higher
 * one or more Docker hosts configured as a swarm
 
-### Building the Images
+### Building the Image
 
-This repository contains two images: `omeka_classic` and `omeka_db`. To build these images, run the following commands from the root of the repository:
+To build the image, run the following command from the root of the repository:
 
 ```
 docker build -t omeka_classic:latest images/omeka_classic
-docker build -t omeka_db:latest images/omeka_db
 ```
 
 Note that the `latest` tag is the tag referred to in the `docker-compose.yml` file. If you use a different tag, update the `docker-compose.yml` file to refer to the new tag before attempting a deployment.

--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Note that the `latest` tag is the tag referred to in the `docker-compose.yml` fi
 
 ### Deployment
 
-To deploy, clone this repo and build the images as directed in the previous section. Execute the following commands to create the environment files that will be mapped into the `omeka_classic` and `omeka_db` services as secrets upon deployment:
+To deploy, clone this repo and build the image as directed in the previous section. Execute the following commands to create the configuration file and database credentials that will be mapped into the `omeka_app` and `db` services as secrets upon deployment:
 
 ```
+echo 'your_db_password' | docker secret create omeka_db_password -
+echo 'your_db_root_password' | docker secret create omeka_db_root_password -
 cp images/omeka_classic/db.ini.example images/omeka_classic/db.ini
-cp images/omeka_db/.env.example images/omeka_db/.env
 ```
 
-Edit the newly created `db.ini` and `.env` files to use your desired database credentials. Note that `username`, `password`, and `database` in `dbi.ini` must match `MYSQL_USER`, `MYSQL_PASSWORD`, and `MYSQL_DATABASE` in `.env`, respectively. Execute the following command from the root of the repository to deploy the application to the swarm:
+Edit the newly created `db.ini` file to use the database credentials that were passed to `docker secret create`. Note that `username`, `password`, and `database` in `dbi.ini` must match `MYSQL_USER`, `MYSQL_PASSWORD`, and `MYSQL_DATABASE` in `docker-compose.yml` and your `omeka_db_password` secret, respectively. Execute the following command from the root of the repository to deploy the application to the swarm:
 
 ```
 docker stack deploy -c docker-compose.yml omeka_classic

--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ docker stack deploy -c docker-compose.yml omeka_classic
 
 Your application should be available at port 80 in the browser.
 
-### Custom Entrypoints
-
-The images defined in this repository use custom entrypoint scripts to handle the secrets that are mapped into the services. These entrypoint scripts are named `entrypoint.sh` and can be found in `images/omeka_classic` and `images/omeka_db`. The `omeka_classic` entrypoint script handles installing the `db_ini` secret as required by Omeka Classic, and the `omeka_db` entrypoint script maps the values specified in the `mysql_env` secret to environment variables used to initialize MySQL. A description of these environment variables and their purpose can be found on the Docker Hub page for the [mysql/mysql-server image](https://hub.docker.com/r/mysql/mysql-server/) under the *Docker Environment Variables* section.
-
 ### Plugins
 
 Omeka applications deployed with this image ship with the following plugins:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
     secrets:
       - source: db_ini
         target: /var/www/html/db.ini
+        uid: '33'
+        gid: '33'
+        mode: 0440
 
 volumes:
   db:

--- a/images/omeka_classic/Dockerfile
+++ b/images/omeka_classic/Dockerfile
@@ -56,9 +56,3 @@ RUN rm /var/www/html/themes/*.zip && rm /var/www/html/plugins/*.zip
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN a2enmod rewrite && service apache2 restart
-
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-
-ENTRYPOINT ["entrypoint.sh"]
-
-CMD ["apache2-foreground"]

--- a/images/omeka_classic/db.ini.example
+++ b/images/omeka_classic/db.ini.example
@@ -10,7 +10,7 @@
 ; <http://omeka.org/codex/Database_Configuration_File>.
 
 [database]
-host     = "omeka_classic_db"
+host     = "db"
 username = "omeka"
 password = "omeka"
 dbname   = "omeka"

--- a/images/omeka_classic/entrypoint.sh
+++ b/images/omeka_classic/entrypoint.sh
@@ -1,7 +1,0 @@
-#! /bin/sh
-
-cp /run/secrets/*db_ini /var/www/html/db.ini
-chmod 640 /var/www/html/db.ini
-chown www-data:www-data /var/www/html/db.ini
-
-exec "$@"


### PR DESCRIPTION
Since we can set the UID / GID / mode of the `db.ini` file when mounting the secret, we don't need to set these permissions in the entrypoint. As such, we don't need a custom entrypoint at all! We can rely on the parent image's entrypoint / command instead. 🙆 